### PR TITLE
6.0.2 - handle dynamic changes to `dropScope` while dragging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.0.2 (2025-09-25)
+- Handle changes to `allowDrop` in `droppable` when `dropScope` changes while dragging
+
 ## 6.0.1 (2024-08-07)
 - Remove Angular version constraint for future versions
 

--- a/projects/demo/src/app/components/delete-item/delete-item.component.html
+++ b/projects/demo/src/app/components/delete-item/delete-item.component.html
@@ -21,11 +21,12 @@
     <div class="col-sm-3">
 
       <div class="card card-inverse card-primary mb-3 text-center" droppable [dragHintClass]="'drag-hint-scale'" [dragOverClass]="'bg-danger'"
-        [dropScope]="'delete'" (onDrop)="onDeleteDrop($event)">
+        [dropScope]="deleteScope" (onDrop)="onDeleteDrop($event)">
         <div class="card-block">
           <blockquote class="card-blockquote">
             <h4 class="card-title"><i class="fa fa-trash" aria-hidden="true"></i> Drop to Delete</h4>
             <p class="card-text">Drop Items here to delete</p>
+            <p *ngIf="countdown !== undefined" class="card-text text-danger">Deletable in {{countdown}}</p>
           </blockquote>
         </div>
       </div>

--- a/projects/demo/src/app/components/delete-item/delete-item.component.ts
+++ b/projects/demo/src/app/components/delete-item/delete-item.component.ts
@@ -1,11 +1,12 @@
-import { Component } from '@angular/core';
-import { DropEvent } from 'ng-drag-drop';
+import { Component, inject } from '@angular/core';
+import { interval, map, take, Subscription, tap, timer } from 'rxjs';
+import { NgDragDropService, DropEvent } from 'ng-drag-drop';
 
 @Component({
-    selector: 'delete-item',
-    templateUrl: './delete-item.component.html',
-    styles: [
-        `
+  selector: 'delete-item',
+  templateUrl: './delete-item.component.html',
+  styles: [
+    `
       div.scroll-list {
         overflow: auto;
         max-height: 70vh;
@@ -17,10 +18,12 @@ import { DropEvent } from 'ng-drag-drop';
         transform: scale(1.1);
       }
     `,
-    ],
-    standalone: false
+  ],
+  standalone: false
 })
 export class DeleteItemComponent {
+  ngDragDropService = inject(NgDragDropService);
+
   deleteItems = [
     { name: 'Angular2' },
     { name: 'AngularJS' },
@@ -28,6 +31,27 @@ export class DeleteItemComponent {
     { name: 'ReactJS' },
     { name: 'Backbone' },
   ];
+  deleteScope = '';
+  countdown?: number;
+
+  dragTimer?: Subscription;
+
+  constructor() {
+    this.ngDragDropService.onDragStart.subscribe(() => {
+      this.dragTimer = timer(0, 1000).pipe(take(6), map((v) => 5 - v), tap(v => this.countdown = v)).subscribe({
+        complete: () => {
+          this.deleteScope = 'delete';
+          this.dragTimer = undefined;
+          this.countdown = undefined;
+        }
+      });
+    });
+    this.ngDragDropService.onDragEnd.subscribe(() => {
+      this.deleteScope = '';
+      this.dragTimer?.unsubscribe();
+      this.countdown = undefined;
+    });
+  }
 
   onDeleteDrop(e: DropEvent) {
     this.removeItem(e.dragData, this.deleteItems);

--- a/projects/ng-drag-drop/package.json
+++ b/projects/ng-drag-drop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucasg04/ng-drag-drop",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Drag & Drop for Angular - based on HTML5 with no external dependencies.",
   "repository": {
     "type": "git",

--- a/projects/ng-drag-drop/src/lib/directives/droppable.directive.ts
+++ b/projects/ng-drag-drop/src/lib/directives/droppable.directive.ts
@@ -11,7 +11,7 @@ import {
   Renderer2,
 } from '@angular/core';
 import { DomHelper } from '../shared/dom-helper';
-import { Subscription, Observable, map, of } from 'rxjs';
+import { Subscription, Observable, map, of, BehaviorSubject } from 'rxjs';
 import { NgDragDropService } from '../ng-drag-drop.service';
 import { DropEvent } from '../shared/drop-event.model';
 
@@ -51,7 +51,13 @@ export class Droppable implements OnInit, OnDestroy {
   /**
    * Defines compatible drag drop pairs. Values must match both in draggable and droppable.dropScope.
    */
-  @Input() dropScope: string | Array<string> | Function = 'default';
+  get dropScope() {
+    return this._dropScope;
+  }
+  @Input() set dropScope(value: string | Array<string> | Function) {
+    this._dropScope = value;
+    this.checkAllowDrop();
+  }
 
   /**
    * Defines if drop is enabled. `true` by default.
@@ -64,6 +70,7 @@ export class Droppable implements OnInit, OnDestroy {
     } else {
       this.unsubscribeService();
     }
+    this.checkAllowDrop();
   }
 
   get dropEnabled() {
@@ -96,6 +103,12 @@ export class Droppable implements OnInit, OnDestroy {
 
   /**
    * @private
+   * Backing field for the dropScope property.
+   */
+  _dropScope: string | Array<string> | Function = 'default';
+
+  /**
+   * @private
    * Field for tracking if service is subscribed.
    * Avoids creating multiple subscriptions of service.
    */
@@ -118,6 +131,12 @@ export class Droppable implements OnInit, OnDestroy {
    * Function for unbinding the drag leave listener
    */
   unbindDragLeaveListener?: Function;
+
+  /**
+   * @private
+   * Function for unbinding the drag leave listener
+   */
+  allowDrop: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor(
     protected el: ElementRef,
@@ -159,7 +178,7 @@ export class Droppable implements OnInit, OnDestroy {
 
   @HostListener('drop', ['$event'])
   drop(e: any) {
-    this.allowDrop().subscribe((result) => {
+    this.allowDrop.subscribe((result) => {
       if (result && this._isDragActive) {
         DomHelper.removeClass(this.el, this.dragOverClass);
         e.preventDefault();
@@ -173,8 +192,8 @@ export class Droppable implements OnInit, OnDestroy {
     });
   }
 
-  allowDrop(): Observable<boolean> {
-    let allowed: boolean | Observable<boolean> = false;
+  checkAllowDrop(): void {
+    let allowed = false;
 
     /* tslint:disable:curly */
     /* tslint:disable:one-line */
@@ -193,15 +212,16 @@ export class Droppable implements OnInit, OnDestroy {
           }).length > 0;
     } else if (typeof this.dropScope === 'function') {
       allowed = this.dropScope(this.ng2DragDropService.dragData);
-      if (allowed instanceof Observable) {
-        return allowed.pipe(map((result) => result && this.dropEnabled));
-      }
+      // TODO: handle observable return value
+      // if (allowed instanceof Observable) {
+      //   return allowed.pipe(map((result) => result && this.dropEnabled));
+      // }
     }
 
     /* tslint:enable:curly */
     /* tslint:disable:one-line */
 
-    return of(allowed && this.dropEnabled);
+    this.allowDrop.next(allowed && this.dropEnabled);
   }
 
   subscribeService() {
@@ -212,7 +232,7 @@ export class Droppable implements OnInit, OnDestroy {
     this.dragStartSubscription = this.ng2DragDropService.onDragStart.subscribe(
       () => {
         this._isDragActive = true;
-        this.allowDrop().subscribe((result) => {
+        this.allowDrop.subscribe((result) => {
           if (result && this._isDragActive) {
             DomHelper.addClass(this.el, this.dragHintClass);
 


### PR DESCRIPTION
This pull request updates the drag-and-drop behavior to better handle dynamic changes to `dropScope` while dragging, and improves the demo UI to provide user feedback during drag operations. The most important changes are grouped below.

### Drag-and-drop logic improvements

* Modified the `droppable` directive to reactively handle changes to `dropScope` while dragging, ensuring that drop eligibility updates immediately if the scope changes. The directive now uses a setter for `dropScope` and a `BehaviorSubject` to track drop allowance.

### Demo UI and behavior enhancements

* Changed the demo's delete area to use a dynamic `deleteScope` property, which is set after a countdown when dragging starts. The countdown is displayed to the user, providing feedback about when deletion is allowed.

### Package update

* Bumped the package version to `6.0.2` to reflect these changes.